### PR TITLE
Prevent calling undefined addLoadEvent

### DIFF
--- a/EmailObfuscation.module
+++ b/EmailObfuscation.module
@@ -253,7 +253,7 @@ class EmailObfuscation extends WireData implements Module, ConfigurableModule {
 
 		// create addresses script block
 		$addrScript = "\n<!-- emo -->\n<script>\n var emo_addr = new Array();\n";
-		$addrScript .= "{$this->addrScript} addLoadEvent(emo_replace());\n</script>\n";
+		$addrScript .= "{$this->addrScript} if(window.addLoadEvent) addLoadEvent(emo_replace());\n</script>\n";
 
 		// append debug info to output
 		if($this->debug) {


### PR DESCRIPTION
On manual JS loading the addLoadEvent function may be unavailable (eg. using script loaders)