### PR TITLE
switch to DOM parser

### DIFF
--- a/EmailObfuscation.info.json
+++ b/EmailObfuscation.info.json
@@ -1,6 +1,6 @@
 {
   "title": "Email Obfuscation (EMO)",
-  "version": 126,
+  "version": 130,
   "summary": "Email Obfuscation module for email addresses with 64 base crypting.",
   "author": "Jukka Hankaniemi (Roope)",
   "href": "https://github.com/BlowbackDesign/EmailObfuscation",

--- a/EmailObfuscation.info.json
+++ b/EmailObfuscation.info.json
@@ -1,6 +1,6 @@
 {
   "title": "Email Obfuscation (EMO)",
-  "version": 125,
+  "version": 126,
   "summary": "Email Obfuscation module for email addresses with 64 base crypting.",
   "author": "Jukka Hankaniemi (Roope)",
   "href": "https://github.com/BlowbackDesign/EmailObfuscation",

--- a/EmailObfuscation.info.json
+++ b/EmailObfuscation.info.json
@@ -1,6 +1,6 @@
 {
   "title": "Email Obfuscation (EMO)",
-  "version": 130,
+  "version": 131,
   "summary": "Email Obfuscation module for email addresses with 64 base crypting.",
   "author": "Jukka Hankaniemi (Roope)",
   "href": "https://github.com/BlowbackDesign/EmailObfuscation",

--- a/EmailObfuscation.module
+++ b/EmailObfuscation.module
@@ -4,7 +4,7 @@
  *
  * Email Obfuscation module for email addresses with 64 base crypting.
  *
- * @version 1.3.0
+ * @version 1.3.1
  * @copyright Blowback https://github.com/BlowbackDesign
  * @license MIT http://opensource.org/licenses/MIT
  *
@@ -336,7 +336,7 @@ class EmailObfuscation extends WireData implements Module, ConfigurableModule
 
 		// create email debug data row
 		if($this->debug) {
-			$this->debugData[$this->addrCount] = array('hash'=>$hash, 'data'=>$matches);
+			$this->debugData[$this->addrCount] = array('hash' => $hash, 'data' => $link);
 		}
 
 		++$this->addrCount;
@@ -391,14 +391,10 @@ class EmailObfuscation extends WireData implements Module, ConfigurableModule
 	 */
 	private function obfuscate($html)
 	{
-		if($this->debug) $start_time = microtime(true);
-
 		libxml_use_internal_errors(true);
 		$doc = new DOMDocument();
 		$doc->loadHTML($html, LIBXML_NOWARNING|LIBXML_COMPACT);
 		$this->parseNode($doc->getElementsByTagName('body')[0]);
-
-		if($this->debug) echo "\n\t<!-- EmailObfuscation processing time: ".round((microtime(true)-$start_time)*1000,3)."msec -->\n";
 
 		return $doc->saveHTML();
 	}

--- a/EmailObfuscation.module
+++ b/EmailObfuscation.module
@@ -4,7 +4,7 @@
  *
  * Email Obfuscation module for email addresses with 64 base crypting.
  *
- * @version 1.2.6
+ * @version 1.3.0
  * @copyright Blowback https://github.com/BlowbackDesign
  * @license MIT http://opensource.org/licenses/MIT
  *
@@ -48,6 +48,76 @@ class EmailObfuscation extends WireData implements Module, ConfigurableModule
 		'selectedTemplates' => array(),
 		'selectedPages' => array(),
 	);
+	/**
+	 * tags to skip for replacement of mail addresses
+	 * head is skipped by root tag
+	 */
+	private const skip_tags = array("audio", "canvas", "embed", "iframe", "img", "input", "math",
+		"object", "output", "option", "script", "svg", "textarea", "video");
+
+	/**
+	 * regex pattern that matches email addresses according to rfc5322
+	 * https://www.npopov.com/2012/06/15/The-true-power-of-regular-expressions.html
+	 *
+	private const rfc5322_pattern = "(?(DEFINE)
+	(?<addr_spec> (?&local_part) @ (?&domain) )
+	(?<local_part> (?&dot_atom) | (?&quoted_string) | (?&obs_local_part) )
+	(?<domain> (?&dot_atom) | (?&domain_literal) | (?&obs_domain) )
+	(?<domain_literal> (?&CFWS)? \[ (?: (?&FWS)? (?&dtext) )* (?&FWS)? \] (?&CFWS)? )
+	(?<dtext> [\x21-\x5a] | [\x5e-\x7e] | (?&obs_dtext) )
+	(?<quoted_pair> \\ (?: (?&VCHAR) | (?&WSP) ) | (?&obs_qp) )
+	(?<dot_atom> (?&CFWS)? (?&dot_atom_text) (?&CFWS)? )
+	(?<dot_atom_text> (?&atext) (?: \. (?&atext) )* )
+	(?<atext> [a-zA-Z0-9!\#$%&'*+\/=?^_`{|}~-]+ )
+	(?<atom> (?&CFWS)? (?&atext) (?&CFWS)? )
+	(?<word> (?&atom) | (?&quoted_string) )
+	(?<quoted_string> (?&CFWS)? \" (?: (?&FWS)? (?&qcontent) )* (?&FWS)? \" (?&CFWS)? )
+	(?<qcontent> (?&qtext) | (?&quoted_pair) )
+	(?<qtext> \x21 | [\x23-\x5b] | [\x5d-\x7e] | (?&obs_qtext) )
+
+	(?<FWS> (?: (?&WSP)* \r\n )? (?&WSP)+ | (?&obs_FWS) )
+	(?<CFWS> (?: (?&FWS)? (?&comment) )+ (?&FWS)? | (?&FWS) )
+	(?<comment> \( (?: (?&FWS)? (?&ccontent) )* (?&FWS)? \) )
+	(?<ccontent> (?&ctext) | (?&quoted_pair) | (?&comment) )
+	(?<ctext> [\x21-\x27] | [\x2a-\x5b] | [\x5d-\x7e] | (?&obs_ctext) )
+
+	(?<obs_domain> (?&atom) (?: \. (?&atom) )* )
+	(?<obs_local_part> (?&word) (?: \. (?&word) )* )
+	(?<obs_dtext> (?&obs_NO_WS_CTL) | (?&quoted_pair) )
+	(?<obs_qp> \\ (?: (?&obs_NO_WS_CTL) | \n | \r ) )
+	(?<obs_FWS> (?&WSP)+ (?: \r\n (?&WSP)+ )* )
+	(?<obs_ctext> (?&obs_NO_WS_CTL) )
+	(?<obs_qtext> (?&obs_NO_WS_CTL) )
+	(?<obs_NO_WS_CTL> [\x01-\x08] | \x0b | \x0c | [\x0e-\x1f] | \x7f )
+
+	(?<VCHAR> [\x21-\x7E] )
+	(?<WSP> [ \t] )
+	)
+	(?&addr_spec)";
+	*/
+
+	/**
+	 * fast regex to scan email addresses
+	 * (alternative to RFC5322)
+	 */
+	private const fast_pattern = "(?!\.)[\w\-_.]*[^.]@\w+\.\w+(\.\w+)?[^.\W]";
+
+	/**
+	 * shortest email addresses that can be detected
+	 * (increases parsing speed)
+	 * x@y.zz -> 6 characters
+	 */
+	private const min_email = 6;
+
+	/**
+	 * regex pattern that matches email addresses
+	 */
+	private const email_pattern = "/".self::fast_pattern."/";
+
+	/**
+	* regex pattern that matches mailto links
+	*/
+	private const mailto_pattern = "/^mailto:".self::fast_pattern."[?,]?/";
 
 	/**
 	 * runtime encode string
@@ -216,18 +286,6 @@ class EmailObfuscation extends WireData implements Module, ConfigurableModule
 	}
 
 	/**
-	 * return regex pattern that matches email addresses
-	 *
-	 */
-	private static function pattern()
-	{
-		$atom = "[-!#$%'*+=?^_`{|}~0-9A-Za-zÀ-ž]+";
-		$name = $atom.'(?:\\.'.$atom.')*';
-		$domain = $atom.'(?:\\.'.$atom.')+';
-		return "<({$name}@{$domain})>";
-	}
-
-	/**
 	 * custom base 64 encoding
 	 *
 	 */
@@ -254,32 +312,17 @@ class EmailObfuscation extends WireData implements Module, ConfigurableModule
 	 * encrypt the match
 	 *
 	 */
-	private function encode($matches)
+	private function encode($link, $pure_mail = false)
 	{
-		// filter out images detected as false positives (@2x file names)
-		if(preg_match('/\.(jpe?g|png|gif|bmp)$/i', $matches[0])) return $matches[0];
-
 		// debug encrypt key
 		if($this->debug && $this->addrCount === 0) {
 			$this->debugData['key'] = $this->getKey();
 		}
 
-		// normalize matches
-		if(isset($matches[2])) {
-			$matches[1] = $matches[1] . '@' . $matches[2];
-			$matches[2] = $matches[3];
-			unset($matches[3]);
-		} else {
-			$matches[2] = $matches[1];
-		}
-		list($found, $email, $anchor) = $matches;
-
-		// link string defaults to what we found
-		$link = $found;
-
 		// add mailto link to plaintext emails when enabled
-		if($this->mailto && $found === $email) {
-			$link = '<a href="mailto:' . $email . '">' . $anchor . '</a>';
+		// check that it is not already mailto
+		if($this->mailto && $pure_mail) {
+			$link = '<a href="mailto:' . $link . '">' . $link . '</a>';
 		}
 
 		// did we use the same link before?
@@ -291,18 +334,55 @@ class EmailObfuscation extends WireData implements Module, ConfigurableModule
 		// get encrypted string
 		$hash = $this->getEmailHashByKey($key);
 
-		// create html of the crypted link
-		$crypted = '<noscript data-emo="' . $hash . '">';
-		$crypted .= preg_match(self::pattern(), $anchor) ? $this->{"noscript$this->lang"} : $anchor;
-		$crypted .= '</noscript>';
-
 		// create email debug data row
 		if($this->debug) {
 			$this->debugData[$this->addrCount] = array('hash'=>$hash, 'data'=>$matches);
 		}
 
 		++$this->addrCount;
-		return $crypted;
+		return $hash;
+	}
+
+	/**
+	 * parse a DOMNode recursive for email addresses
+	 * The function scans text nodes for email addresses and
+	 * anchors with href attributes for mailto links.
+	 * https://www.php.net/manual/en/dom.constants.php
+	 */
+	private function parseNode($node)
+	{
+		if ($node->nodeType == XML_COMMENT_NODE) return;
+		if (in_array($node->nodeName, self::skip_tags)) return;
+		if ($node->hasChildNodes() == FALSE) {
+			if ($node->nodeType != XML_TEXT_NODE || strlen(trim($node->nodeValue)) < self::min_email) return;
+			preg_match_all(self::email_pattern, $node->nodeValue, $matches, PREG_OFFSET_CAPTURE);
+			$end = 0;
+			foreach($matches[0] as $match) {
+				if (empty($match)) continue;
+				if ($end < $match[1]) {
+					$text = $node->ownerDocument->createTextNode(substr($node->nodeValue, $end, $match[1]-$end));
+					$node->parentNode->insertBefore($text, $node);
+				}
+				$end = $match[1] + strlen($match[0]);
+				$noscript = $node->ownerDocument->createElement("noscript");
+				$noscript->setAttribute("data-emo", $this->encode($match[0], true));
+				$node->parentNode->insertBefore($noscript, $node);
+			}
+			$text = $node->ownerDocument->createTextNode(substr($node->nodeValue, $end));
+			$node->parentNode->replaceChild($text, $node);
+		} else {
+		  foreach($node->childNodes as $child) {
+			if ($child->hasAttributes() && $child->nodeName == "a" && !empty($attr = $child->attributes->getNamedItem("href"))) {
+				if (preg_match(self::mailto_pattern, $attr->nodeValue)) {
+					$noscript = $node->ownerDocument->createElement("noscript");
+					$noscript->setAttribute("data-emo", $this->encode($node->ownerDocument->saveHTML($child), false));
+					$node->replaceChild($noscript, $child);
+				}
+				continue; // avoid nested anchor tags
+			}
+			$this->parseNode($child);
+		  }
+		}
 	}
 
 	/**
@@ -311,36 +391,16 @@ class EmailObfuscation extends WireData implements Module, ConfigurableModule
 	 */
 	private function obfuscate($html)
 	{
-		$skip = array(
-			'<head' => "((?:<head).*(?:<\/head>))",
-			'<scri' => "((?:<script).*(?:<\/script>))",
-			'<text' => "((?:<textarea).*(?:<\/textarea>))",
-			'<opti' => "((?:<option).*(?:<\/option>))",
-			'<outp' => "((?:<output).*(?:<\/output>))",
-			'<inpu' => "((?:<input).*(?:>))",
-			'value' => "((?:value=['\"]).*(?:['\"]))",
-			'label' => "((?:label=['\"]).*(?:['\"]))",
-			'data-' => "((?:data-[A-Z0-9.-]+=['\"]).*(?:['\"]))",
-		);
+		if($this->debug) $start_time = microtime(true);
 
-		$tags = "#" . implode('|', $skip) . "#isUu";
-		$mailto = "#<a[^>]*mailto:([^'\"@]+)@([^'\"]+)['\"][^>]*>(.*)<\/a>#isUu";
-		$output = "";
+		libxml_use_internal_errors(true);
+		$doc = new DOMDocument();
+		$doc->loadHTML($html, LIBXML_NOWARNING|LIBXML_COMPACT);
+		$this->parseNode($doc->getElementsByTagName('body')[0]);
 
-		// split html to parts by tags
-		foreach(preg_split($tags, $html, 0, PREG_SPLIT_NO_EMPTY|PREG_SPLIT_DELIM_CAPTURE) as $str) {
+		if($this->debug) echo "\n\t<!-- EmailObfuscation processing time: ".round((microtime(true)-$start_time)*1000,3)."msec -->\n";
 
-			// encode mailto links and email addresses from the parts
-			if(!in_array(substr($str, 0, 5), array_keys($skip))) {
-				$str = preg_replace_callback($mailto, array($this, 'encode'), $str);
-				$str = preg_replace_callback(self::pattern(), array($this, 'encode'), $str);
-			}
-
-			// glue parts back to output
-			$output .= $str;
-		}
-
-		return $output;
+		return $doc->saveHTML();
 	}
 
 	/**

--- a/EmailObfuscation.module
+++ b/EmailObfuscation.module
@@ -4,7 +4,7 @@
  *
  * Email Obfuscation module for email addresses with 64 base crypting.
  *
- * @version 1.2.5
+ * @version 1.2.6
  * @copyright Blowback https://github.com/BlowbackDesign
  * @license MIT http://opensource.org/licenses/MIT
  *
@@ -244,8 +244,7 @@ class EmailObfuscation extends WireData implements Module, ConfigurableModule
 			$e2 = (($c1 & 3) << 4) + ($c2 >> 4);
 			$e3 = (($c2 & 15) << 2) + ($c3 >> 6);
 			$e4 = $c3 & 63;
-			if(is_nan($c2)) $e3 = $e4 = 64;
-			else if(is_nan($c3)) $e4 = 64;
+
 			$out .= $key[$e1] . $key[$e2] . $key[$e3] . $key[$e4];
 		}
 		return $out;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "emailobfuscation",
-  "version": "1.2.6",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "emailobfuscation",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "emailobfuscation",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emailobfuscation",
-  "version": "1.2.6",
+  "version": "1.3.0",
   "description": "Email Obfuscation module for email addresses with 64 base crypting.",
   "author": "Jukka Hankaniemi (Roope)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emailobfuscation",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Email Obfuscation module for email addresses with 64 base crypting.",
   "author": "Jukka Hankaniemi (Roope)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emailobfuscation",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Email Obfuscation module for email addresses with 64 base crypting.",
   "author": "Jukka Hankaniemi (Roope)",
   "license": "MIT",


### PR DESCRIPTION
Hi!

As mentioned in https://processwire.com/talk/topic/2916-email-obfuscation-emo/?do=findComment&comment=228050 parsing of long strings causes issues with the previous implementation only using regex. Additionally, I had sometimes issues with the regex_split causing my HTML to break and thus not render the page.
This PR changes the replacing with manipulations of the DOM tree and thus is HTML context sensitive. Replacement is done in text and anchors only.
Hope it is helpful to a number of people!

fixes issue https://github.com/BlowbackDesign/EmailObfuscation/issues/13
solves PR https://github.com/BlowbackDesign/EmailObfuscation/pull/14